### PR TITLE
Add missing dependency

### DIFF
--- a/notebooks/combine_results.ipynb
+++ b/notebooks/combine_results.ipynb
@@ -35,10 +35,39 @@
    "outputs": [],
    "source": [
     "import logging\n",
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
     "from typing import List\n",
     "\n",
-    "import pandas as pd\n",
-    "\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is needed for notebooks in case jupyter is started directly in the notebooks directory\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_working_directory = Path(\".\").resolve()\n",
+    "if current_working_directory.name == \"notebooks\":\n",
+    "    sys.path.insert(0, os.fspath(current_working_directory.parent))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from src.constants import OUTPUT_DIR, RANDOM_SEED\n",
     "from src.utils import (\n",
     "    configure_plots,\n",

--- a/notebooks/deit_rvl_cdip.ipynb
+++ b/notebooks/deit_rvl_cdip.ipynb
@@ -45,17 +45,44 @@
    "source": [
     "import logging\n",
     "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
     "from typing import List\n",
     "\n",
     "import numpy as np\n",
     "import torch\n",
-    "import torch.nn.functional as F\n",
     "from kyle.evaluation import EvalStats\n",
     "from sklearn.metrics import accuracy_score\n",
     "from torch.utils.data import DataLoader\n",
     "from tqdm.auto import tqdm\n",
-    "from transformers import AutoFeatureExtractor, AutoModelForImageClassification\n",
-    "\n",
+    "from transformers import AutoFeatureExtractor, AutoModelForImageClassification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is needed for notebooks in case jupyter is started directly in the notebooks directory\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_working_directory = Path(\".\").resolve()\n",
+    "if current_working_directory.name == \"notebooks\":\n",
+    "    sys.path.insert(0, os.fspath(current_working_directory.parent))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED\n",
     "from src.data_and_models.rvl_cdip import download_rvl_cdip\n",
     "from src.utils import (\n",

--- a/notebooks/distilbert_imdb.ipynb
+++ b/notebooks/distilbert_imdb.ipynb
@@ -47,6 +47,8 @@
    "source": [
     "import logging\n",
     "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
     "from typing import List\n",
     "\n",
     "import numpy as np\n",
@@ -57,8 +59,34 @@
     "from sklearn.metrics import accuracy_score\n",
     "from torch.utils.data import DataLoader\n",
     "from tqdm.auto import tqdm\n",
-    "from transformers import DistilBertForSequenceClassification, DistilBertTokenizer\n",
-    "\n",
+    "from transformers import DistilBertForSequenceClassification, DistilBertTokenizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is needed for notebooks in case jupyter is started directly in the notebooks directory\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_working_directory = Path(\".\").resolve()\n",
+    "if current_working_directory.name == \"notebooks\":\n",
+    "    sys.path.insert(0, os.fspath(current_working_directory.parent))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED\n",
     "from src.utils import (\n",
     "    configure_plots,\n",

--- a/notebooks/lightgbm_sorel20m.ipynb
+++ b/notebooks/lightgbm_sorel20m.ipynb
@@ -52,8 +52,27 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "from kyle.evaluation import EvalStats\n",
-    "from sklearn.metrics import accuracy_score\n",
-    "\n",
+    "from sklearn.metrics import accuracy_score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is needed for notebooks in case jupyter is started directly in the notebooks directory\n",
+    "current_working_directory = Path(\".\").resolve()\n",
+    "if current_working_directory.name == \"notebooks\":\n",
+    "    sys.path.insert(0, os.fspath(current_working_directory.parent))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED\n",
     "from src.data_and_models.sorel20m import download_sorel20m\n",
     "from src.utils import (\n",

--- a/notebooks/random_forest_synthetic.ipynb
+++ b/notebooks/random_forest_synthetic.ipynb
@@ -44,11 +44,40 @@
    "outputs": [],
    "source": [
     "import logging\n",
+    "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
     "from typing import List\n",
     "\n",
     "import pandas as pd\n",
-    "from kyle.evaluation import EvalStats\n",
-    "\n",
+    "from kyle.evaluation import EvalStats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is needed for notebooks in case jupyter is started directly in the notebooks directory\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_working_directory = Path(\".\").resolve()\n",
+    "if current_working_directory.name == \"notebooks\":\n",
+    "    sys.path.insert(0, os.fspath(current_working_directory.parent))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from src.constants import OUTPUT_DIR, RANDOM_SEED\n",
     "from src.utils import (\n",
     "    configure_plots,\n",

--- a/notebooks/resnet56_cifar10.ipynb
+++ b/notebooks/resnet56_cifar10.ipynb
@@ -44,6 +44,8 @@
    "source": [
     "import logging\n",
     "import os\n",
+    "import sys\n",
+    "from pathlib import Path\n",
     "from typing import List\n",
     "\n",
     "# This import is needed to avoid a circular import error\n",
@@ -55,8 +57,34 @@
     "from kyle.evaluation import EvalStats\n",
     "from kyle.models.resnet import resnet56\n",
     "from sklearn.metrics import accuracy_score\n",
-    "from tqdm.auto import tqdm\n",
-    "\n",
+    "from tqdm.auto import tqdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is needed for notebooks in case jupyter is started directly in the notebooks directory\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_working_directory = Path(\".\").resolve()\n",
+    "if current_working_directory.name == \"notebooks\":\n",
+    "    sys.path.insert(0, os.fspath(current_working_directory.parent))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED\n",
     "from src.data_and_models.resnet import download_resnet_models\n",
     "from src.utils import (\n",

--- a/poetry.lock
+++ b/poetry.lock
@@ -794,6 +794,18 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "kornia"
+version = "0.5.11"
+description = "Open Source Differentiable Computer Vision Library for PyTorch"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+packaging = "*"
+torch = ">=1.6.0"
+
+[[package]]
 name = "kyle-calibration"
 version = "0.1.6"
 description = "appliedAI classifier calibration library"
@@ -2179,7 +2191,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "0affc69c5fbcd056e3b89e1a50f21ced4924d8b6468cab40d9843db229dd1538"
+content-hash = "7dc2302e64bb046682417890175b24304065b7a3d5b5a926a80de257c04fb710"
 
 [metadata.files]
 absl-py = [
@@ -2627,6 +2639,10 @@ kiwisolver = [
     {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6cb459eea32a4e2cf18ba5fcece2dbdf496384413bc1bae15583f19e567f3b2"},
     {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:36dafec3d6d6088d34e2de6b85f9d8e2324eb734162fba59d2ba9ed7a2043d5b"},
     {file = "kiwisolver-1.4.4.tar.gz", hash = "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955"},
+]
+kornia = [
+    {file = "kornia-0.5.11-py2.py3-none-any.whl", hash = "sha256:854db52db6b84e74004db18612278599737efbe22a1db8744a1c69a185e30118"},
+    {file = "kornia-0.5.11.tar.gz", hash = "sha256:c2e3dd3f27a650b284fc8d261b9a7cba414c4d0a01e4d7ae518fd1466e7f3085"},
 ]
 kyle-calibration = [
     {file = "kyle-calibration-0.1.6.tar.gz", hash = "sha256:d1cecf080ff4018eb49f77a460ba8e505ae5e5f0db1138d9a817cb4210a7e378"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ boto3 = "1.21.6"
 gdown = "4.4.0"
 requests = "2.27.1"
 jupyterlab = "^3.4.8"
+kornia = "^0.5"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.20.0"

--- a/src/experiments/combine_results.py
+++ b/src/experiments/combine_results.py
@@ -10,10 +10,20 @@ that will be used to present the results.
 # Imports
 # -------
 import logging
+import os
+import sys
+from pathlib import Path
 from typing import List
 
 import pandas as pd
 
+# %%
+# This is needed for notebooks in case jupyter is started directly in the notebooks directory
+current_working_directory = Path(".").resolve()
+if current_working_directory.name == "notebooks":
+    sys.path.insert(0, os.fspath(current_working_directory.parent))
+
+# %%
 from src.constants import OUTPUT_DIR, RANDOM_SEED
 from src.utils import (
     configure_plots,

--- a/src/experiments/deit_rvl_cdip.py
+++ b/src/experiments/deit_rvl_cdip.py
@@ -20,17 +20,25 @@ Since the model's accuracy is pretty high it is, as expected, well calibrated
 # -------
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import List
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 from kyle.evaluation import EvalStats
 from sklearn.metrics import accuracy_score
 from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 from transformers import AutoFeatureExtractor, AutoModelForImageClassification
 
+# %%
+# This is needed for notebooks in case jupyter is started directly in the notebooks directory
+current_working_directory = Path(".").resolve()
+if current_working_directory.name == "notebooks":
+    sys.path.insert(0, os.fspath(current_working_directory.parent))
+
+# %%
 from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED
 from src.data_and_models.rvl_cdip import download_rvl_cdip
 from src.utils import (

--- a/src/experiments/distilbert_imdb.py
+++ b/src/experiments/distilbert_imdb.py
@@ -22,6 +22,8 @@ Since the model's accuracy is pretty high it is, as expected, well calibrated
 # -------
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import List
 
 import numpy as np
@@ -34,6 +36,13 @@ from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 from transformers import DistilBertForSequenceClassification, DistilBertTokenizer
 
+# %%
+# This is needed for notebooks in case jupyter is started directly in the notebooks directory
+current_working_directory = Path(".").resolve()
+if current_working_directory.name == "notebooks":
+    sys.path.insert(0, os.fspath(current_working_directory.parent))
+
+# %%
 from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED
 from src.utils import (
     configure_plots,

--- a/src/experiments/lightgbm_sorel20m.py
+++ b/src/experiments/lightgbm_sorel20m.py
@@ -29,6 +29,14 @@ import numpy as np
 from kyle.evaluation import EvalStats
 from sklearn.metrics import accuracy_score
 
+# %%
+
+# This is needed for notebooks in case jupyter is started directly in the notebooks directory
+current_working_directory = Path(".").resolve()
+if current_working_directory.name == "notebooks":
+    sys.path.insert(0, os.fspath(current_working_directory.parent))
+
+# %%
 from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED
 from src.data_and_models.sorel20m import download_sorel20m
 from src.utils import (

--- a/src/experiments/random_forest_synthetic.py
+++ b/src/experiments/random_forest_synthetic.py
@@ -19,11 +19,21 @@ As is common with random forests, the resulting model is highly miscalibrated
 # Imports
 # -------
 import logging
+import os
+import sys
+from pathlib import Path
 from typing import List
 
 import pandas as pd
 from kyle.evaluation import EvalStats
 
+# %%
+# This is needed for notebooks in case jupyter is started directly in the notebooks directory
+current_working_directory = Path(".").resolve()
+if current_working_directory.name == "notebooks":
+    sys.path.insert(0, os.fspath(current_working_directory.parent))
+
+# %%
 from src.constants import OUTPUT_DIR, RANDOM_SEED
 from src.utils import (
     configure_plots,

--- a/src/experiments/resnet56_cifar10.py
+++ b/src/experiments/resnet56_cifar10.py
@@ -19,6 +19,8 @@ Since the model's accuracy is pretty high it is, as expected, well calibrated
 # -------
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import List
 
 # This import is needed to avoid a circular import error
@@ -32,6 +34,13 @@ from kyle.models.resnet import resnet56
 from sklearn.metrics import accuracy_score
 from tqdm.auto import tqdm
 
+# %%
+# This is needed for notebooks in case jupyter is started directly in the notebooks directory
+current_working_directory = Path(".").resolve()
+if current_working_directory.name == "notebooks":
+    sys.path.insert(0, os.fspath(current_working_directory.parent))
+
+# %%
 from src.constants import DATA_DIR, OUTPUT_DIR, RANDOM_SEED
 from src.data_and_models.resnet import download_resnet_models
 from src.utils import (


### PR DESCRIPTION
This PR adds a missing dependency, `kornia`, that is used when loading the CIFAR10 dataset for the ResNet experiment.

It also makes sure the `src` package is importable inside the notebooks even if jupyter is started inside the notebooks directory.